### PR TITLE
Bump upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
         run: zstdmt --fast oci-image.tar
 
       - name: Upload OCI image archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oci-image.tar.zst
           path: oci-image.tar.zst

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG \
-  ALPINE_IMAGE=docker.io/library/alpine:3.18.4 \
-  GOLANG_IMAGE=docker.io/library/golang:1.20.8-alpine \
+  ALPINE_IMAGE=docker.io/library/alpine:3.21.3 \
+  GOLANG_IMAGE=docker.io/library/golang:1.24.2-alpine \
   VERSION=1.3.0 \
   HASH=f9871b9f6ccb51d2b264532e96521e44f926928f91434b56ce135c95becf2901
 


### PR DESCRIPTION
v3 was deprecated 30 Jan 2025.
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/