### PR TITLE
Add Renovate configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,20 @@
-ARG \
-  ALPINE_IMAGE=docker.io/library/alpine:3.24.1 \
-  GOLANG_IMAGE=docker.io/library/golang:1.26.4-alpine3.24 \
-  VERSION=1.9.1 \
-  HASH=34bd82d47e981940751619c9cc44c095bb90bfcaf8d71865cbb822c37690a764
+ARG ALPINE_IMAGE=docker.io/library/alpine:3.24.1
+ARG GOLANG_IMAGE=docker.io/library/golang:1.26.4-alpine3.24
+# renovate: datasource=github-tags depName=containernetworking/plugins
+ARG VERSION=1.9.1 REVISION=adc3e6b5b581638afbd194cf2e9319ecbb0151a1
+
 
 FROM --platform=$BUILDPLATFORM $GOLANG_IMAGE AS sources
+RUN apk add --no-cache git
 ENV GOTOOLCHAIN=local GOTELEMETRY=off
 WORKDIR /go/src/containernetworking-plugins
-ARG VERSION HASH
-RUN --mount=type=tmpfs,target=/tmp \
-  set -euo pipefail \
-  && wget -qO /tmp/sources.tar.gz https://github.com/containernetworking/plugins/archive/refs/tags/v$VERSION.tar.gz \
-  && { echo $HASH /tmp/sources.tar.gz | sha256sum -c -; } || { sha256sum /tmp/sources.tar.gz; exit 1; } \
-  && tar xf /tmp/sources.tar.gz --strip-components=1
+ARG REVISION
+RUN git -c advice.detachedHead=false clone --revision $REVISION --depth=1 https://github.com/containernetworking/plugins.git .
 
 
 FROM sources AS bins
-ARG TARGETARCH SOURCE_DATE_EPOCH
-RUN --mount=type=cache,id=calico-gocache-$TARGETARCH,target=/root/.cache/go-build \
+ARG TARGETARCH SOURCE_DATE_EPOCH VERSION
+RUN --mount=type=cache,id=containernetworking-plugins-gocache-$TARGETARCH,target=/root/.cache/go-build \
   --network=none \
   CGO_ENABLED=0 GOARCH=$TARGETARCH ./build_linux.sh -trimpath -buildvcs=false \
     -ldflags "-s -w -extldflags -static -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=v$VERSION"
@@ -37,7 +34,6 @@ FROM scratch
 LABEL org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.source="https://github.com/k0sproject/cni-node"
 COPY --from=baselayout / /
-ARG VERSION
 COPY --from=bins /go/src/containernetworking-plugins/bin/ /opt/cni/bin/
 ENTRYPOINT ["/bin/cni-node"]
 CMD ["install"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    ":configMigration",
+    ":gitSignOff",
+    ":semanticCommitsDisabled"
+  ],
+  "gitAuthor": "k0s-bot <110385897+k0s-bot@users.noreply.github.com>",
+  "labels": [
+    "dependencies"
+  ],
+  "prTitleStrict": true,
+  "commitMessageAction": "Bump",
+  "commitMessageTopic": "{{depName}}",
+  "groupSingleUpdates": false,
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "enabledManagers": [
+    "github-actions",
+    "dockerfile",
+    "custom.regex"
+  ],
+  "packageRules": [
+    {
+      "description": "No digest-only bumps",
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Bump the Alpine-based Go image, including the -alpineX.Y suffix",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchPackageNames": [
+        "docker.io/library/golang"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-alpine(?<build>\\d+)\\.(?<revision>\\d+)$"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Generic version bumps based on comments",
+      "managerFilePatterns": [
+        "**/Dockerfile*",
+        "**/*.yaml",
+        "**/*.yml"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n[^:=\\n]+[:=][ \\t]*[\"']?(?<currentValue>[^@\\s\"']+)(?:(@|[^:=\\n]+[:=][ \\t]*[\"']?)(?<currentDigest>[0-9a-f]{7,}))?[\"']?[ \\t]*(?:#|\\n)",
+        "[=:][ \\t]*[\"']?(?<currentValue>\\S+?)[\"']?[ \\t]*# renovate: datasource=(?<datasource>\\S+)( registryUrl=(?<registryUrl>.+))? depName=(?<depName>\\S+)( versioning=(?<versioning>.+))?\\n"
+      ],
+      "datasourceTemplate": "{{{datasource}}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.+)"
+    }
+  ]
+}


### PR DESCRIPTION
The GitHub Actions workflow is still missing, but everything else is setup, mostly how the k0s repo is doing it, stripped down and adapted to the needs of this repo:

* Do checkouts based on git commits. The git archive output is not guaranteed to be stable across git versions, so it might change, even if the extracted contents are identical. Use Renovate to bump both the version and the commit.
* Manage GitHub Action version bumps, no need for Dependabot.
* Pin OCI images using their digest.
* Add some special handling for the -alpineX.Y tag suffix.